### PR TITLE
feat(baseline): freeze v12 ground truth and gate regressions in CI (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
       # floor. README points at this check; keep it wired.
       run: npm run block-policy:check
 
+    - name: Check ground-truth baseline holds
+      if: matrix.node-version == 22
+      # The frozen v12 GROUND TRUTH (oracle recall, real-corpus precision,
+      # EG-viable fraction) must be held or beaten by every change. Fails if
+      # a live metric regressed below its committed floor, or if the
+      # reference floors were hand-edited out of step with the code
+      # constants. See benchmarks/baselines/ground-truth-v12.json.
+      run: npm run baseline:check
+
     - name: Publish test summary
       if: always() && matrix.node-version == 22
       run: |

--- a/benchmarks/baselines/ground-truth-v12.json
+++ b/benchmarks/baselines/ground-truth-v12.json
@@ -1,0 +1,79 @@
+{
+  "schema": "swarm.ground-truth.v12",
+  "generatedAt": "2026-07-06T03:27:47.884Z",
+  "computedBy": "scripts/baseline/freeze-ground-truth.ts",
+  "note": "Frozen GROUND TRUTH the v12 upgrade must hold or beat. Floors are code constants in scripts/baseline/ground-truth.ts (GROUND_TRUTH_V12); this file is the committed, human-readable mirror. Guarded by npm run baseline:check. Re-freeze with npm run baseline:freeze after a measured improvement, then raise the code floors to match.",
+  "sources": {
+    "benchmarks/oracle-corpus/oracle-results.json": {
+      "sha256": "198cc8e7dce95a1eddcb72708576041cf428af1b9cbc31a97fc7f078e76d7a4f",
+      "bytes": 2715
+    },
+    "benchmarks/real-corpus/scores-outcome/latest.json": {
+      "sha256": "2c0e4d6f4bb0d2dd1f055331086bc95dd8f690ea93d2168a6eabccab9a8a6b7e",
+      "bytes": 6892
+    },
+    "benchmarks/real-corpus/eg-viability.json": {
+      "sha256": "8075c9c51651aedd86fb6e4f8cb55e81f08cebd704dbeada7f855b75fed6d58b",
+      "bytes": 89009
+    }
+  },
+  "floors": [
+    {
+      "id": "oracle-structural-recall",
+      "label": "Oracle structural detector recall (true positives over injections)",
+      "floor": 258,
+      "denominator": 275,
+      "source": "benchmarks/oracle-corpus/oracle-results.json",
+      "note": "Sum of per-detector tp across 11 structural detectors. Deterministic and byte-identical across runs; no judge involved.",
+      "liveAtFreeze": 258
+    },
+    {
+      "id": "oracle-overall-recall",
+      "label": "Oracle overall recall including judge-primary semantic categories",
+      "floor": 301,
+      "denominator": 325,
+      "source": "benchmarks/oracle-corpus/oracle-results.json",
+      "note": "Structural tp plus semantic judgeTp (goal-not-fixed, cheat-mock-mutation). The semantic component replays from the committed qwen3.6 v1-conservative judge cache.",
+      "liveAtFreeze": 301
+    },
+    {
+      "id": "real-corpus-precision-point-vs-interval",
+      "label": "Real-corpus PR-level union precision (point) held above the frozen interval floor",
+      "floor": 0.09663835601719065,
+      "denominator": null,
+      "source": "benchmarks/real-corpus/scores-outcome/latest.json",
+      "note": "Live point precision must stay at or above the frozen Wilson-95 lower bound. Outcome-grounded over 197 PRs at an 11.2% bad base rate; point 0.217, interval [0.097, 0.419].",
+      "liveAtFreeze": 0.21739130434782608
+    },
+    {
+      "id": "real-corpus-precision-wilson-lower",
+      "label": "Real-corpus PR-level union precision Wilson-95 lower bound",
+      "floor": 0.09663835601719065,
+      "denominator": null,
+      "source": "benchmarks/real-corpus/scores-outcome/latest.json",
+      "note": "The interval floor itself must not collapse below where it was frozen.",
+      "liveAtFreeze": 0.09663835601719065
+    },
+    {
+      "id": "eg-viable-count",
+      "label": "Execution-grounded-viable PRs over the 197-PR corpus",
+      "floor": 12,
+      "denominator": 197,
+      "source": "benchmarks/real-corpus/eg-viability.json",
+      "note": "Phase 2 (pytest and Go runners) must beat this; as a floor it must never drop. The sandbox is Node-only today, so 185 of 197 PRs are dark.",
+      "liveAtFreeze": 12
+    }
+  ],
+  "context": {
+    "realCorpusRecall": 0.22727272727272727,
+    "realCorpusF1": 0.22222222222222224,
+    "realCorpusTruePositive": 5,
+    "realCorpusFalsePositive": 18,
+    "egScreened": 197,
+    "proofTierProvenFindingPrecision": {
+      "n": 0,
+      "precision": null,
+      "note": "No fully-controlled block trigger has fired on the EG-viable slice; proven-finding precision is undefined (n=0). Recorded for honesty, not gated. Phase 4 lights this up only once n is real and the Wilson-95 lower bound clears 0.90."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "labeling:outcome": "tsc -p tsconfig.build.json && node dist/scripts/labeling/outcome-labels.js",
     "promotions:compute": "tsc -p tsconfig.build.json && node dist/scripts/promotions/compute-promotions.js",
     "promotions:check": "node dist/scripts/promotions/check-policy.js",
+    "baseline:freeze": "tsc -p tsconfig.build.json && node dist/scripts/baseline/freeze-ground-truth.js",
+    "baseline:check": "node dist/scripts/baseline/check-ground-truth.js",
     "block-eligibility:calibrate": "tsc -p tsconfig.build.json && node dist/scripts/gate/run-trigger-calibration.js",
     "block-eligibility:compute": "tsc -p tsconfig.build.json && node dist/scripts/gate/compute-block-eligibility.js",
     "block-eligibility:full": "tsc -p tsconfig.build.json && node dist/scripts/gate/run-trigger-calibration.js && node dist/scripts/gate/compute-block-eligibility.js",

--- a/scripts/baseline/check-ground-truth.ts
+++ b/scripts/baseline/check-ground-truth.ts
@@ -1,0 +1,68 @@
+// CI guard: the committed ground-truth reference must still carry the code
+// floors (nobody hand-lowered the bar), and the live metrics recomputed from
+// the current committed artifacts must sit at or above every floor. This is
+// what stops the v12 upgrade from regressing oracle recall or real-corpus
+// precision below the frozen baseline while shipping unrelated work. Mirrors
+// scripts/promotions/check-policy.ts and scripts/gate/check-block-policy.ts.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  evaluateBaseline,
+  GROUND_TRUTH_V12,
+  readLiveMetrics,
+  referenceMatchesConstants,
+  type FrozenReference,
+} from './ground-truth';
+
+const REFERENCE = path.join('benchmarks', 'baselines', 'ground-truth-v12.json');
+
+function fail(message: string): void {
+  process.stderr.write(`check-ground-truth: ${message}\n`);
+  process.exitCode = 1;
+}
+
+function main(): void {
+  if (!fs.existsSync(REFERENCE)) {
+    fail(`reference file not found: ${REFERENCE}. Run: npm run baseline:freeze`);
+    return;
+  }
+  const ref = JSON.parse(fs.readFileSync(REFERENCE, 'utf8')) as FrozenReference;
+
+  const mismatch = referenceMatchesConstants(ref);
+  if (mismatch !== null) {
+    fail(mismatch);
+    return;
+  }
+
+  const live = readLiveMetrics();
+  const result = evaluateBaseline(GROUND_TRUTH_V12, live);
+  if (!result.pass) {
+    for (const r of result.regressions) {
+      process.stderr.write(
+        `check-ground-truth: REGRESSION ${r.id}: live ${r.live} < floor ${r.floor} ` +
+          `(${r.label}); read from ${r.source}\n`,
+      );
+    }
+    fail(
+      `${result.regressions.length} of ${result.checked} frozen floors regressed. A metric that ` +
+        'genuinely dropped is not admissible; fix the change. Only if a floor was superseded by a ' +
+        'better measurement do you re-freeze: npm run baseline:freeze, then raise the ' +
+        'GROUND_TRUTH_V12 floors in scripts/baseline/ground-truth.ts.',
+    );
+    return;
+  }
+
+  const oracleTp = live.oracleStructuralTp + live.oracleSemanticJudgeTp;
+  const oracleN = live.oracleStructuralInjections + live.oracleSemanticInjections;
+  process.stdout.write(
+    `check-ground-truth: all ${result.checked} floors held (oracle ${oracleTp}/${oracleN}, ` +
+      `real-corpus precision ${live.realCorpusPrecisionPoint.toFixed(3)} ` +
+      `[wilson-lower ${live.realCorpusPrecisionWilsonLower.toFixed(3)}], ` +
+      `eg-viable ${live.egViableCount}/${live.egScreened})\n`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/baseline/freeze-ground-truth.ts
+++ b/scripts/baseline/freeze-ground-truth.ts
@@ -1,0 +1,27 @@
+// Regenerate the committed ground-truth reference from the current artifacts.
+// Run after a measured improvement, then raise the GROUND_TRUTH_V12 floors in
+// scripts/baseline/ground-truth.ts to match. Never run this to paper over a
+// regression: the whole point of the reference is that the bar only moves up.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildFrozenReference, DEFAULT_SOURCES, readLiveMetrics } from './ground-truth';
+
+const OUT = path.join('benchmarks', 'baselines', 'ground-truth-v12.json');
+
+function main(): void {
+  const live = readLiveMetrics();
+  const ref = buildFrozenReference(live, DEFAULT_SOURCES, new Date().toISOString());
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, `${JSON.stringify(ref, null, 2)}\n`, 'utf8');
+  process.stdout.write(
+    `freeze-ground-truth: wrote ${OUT} (${ref.floors.length} floors; oracle ` +
+      `${live.oracleStructuralTp + live.oracleSemanticJudgeTp}/` +
+      `${live.oracleStructuralInjections + live.oracleSemanticInjections}, real-corpus precision ` +
+      `${live.realCorpusPrecisionPoint.toFixed(3)}, eg-viable ${live.egViableCount}/${live.egScreened})\n`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/baseline/ground-truth.ts
+++ b/scripts/baseline/ground-truth.ts
@@ -1,0 +1,385 @@
+// The frozen v12 ground-truth baseline: the measured numbers the upgrade
+// must hold or beat. Each floor names the committed artifact its live value
+// is read from and the direction a regression would move it. The floors are
+// code constants (GROUND_TRUTH_V12) so the bar cannot be quietly lowered by
+// hand-editing the committed reference JSON; the check asserts the reference
+// still carries these exact floors AND that the live metrics recomputed from
+// the current artifacts sit at or above every one. Mirrors the compute/check
+// discipline in scripts/promotions/check-policy.ts and
+// scripts/gate/check-block-policy.ts.
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+
+/** A single measured floor the upgrade must hold or beat. */
+export interface BaselineFloor {
+  /** Stable metric id, e.g. "oracle-structural-recall". */
+  readonly id: string;
+  /** One-line human description. */
+  readonly label: string;
+  /** The value the live metric must stay at or above. */
+  readonly floor: number;
+  /** Denominator for count-style floors (recall counts), else null. */
+  readonly denominator: number | null;
+  /** Committed artifact the live value is read from, repo-relative. */
+  readonly source: string;
+  /** Why this floor exists and how the live value is derived. */
+  readonly note: string;
+}
+
+/**
+ * The v12 baseline, frozen from the current committed artifacts. Numbers are
+ * the exact GROUND TRUTH the mission must hold or beat; every one is read back
+ * from a committed file at check time, never re-derived.
+ *
+ * Oracle recall is split into a deterministic structural floor (recomputable
+ * on any machine) and an overall floor that folds the two judge-primary
+ * semantic categories (replayed from the committed judge cache, since this
+ * repo cannot run the local judge on GPU-less hardware).
+ */
+export const GROUND_TRUTH_V12: readonly BaselineFloor[] = [
+  {
+    id: 'oracle-structural-recall',
+    label: 'Oracle structural detector recall (true positives over injections)',
+    floor: 258,
+    denominator: 275,
+    source: 'benchmarks/oracle-corpus/oracle-results.json',
+    note: 'Sum of per-detector tp across 11 structural detectors. Deterministic and byte-identical across runs; no judge involved.',
+  },
+  {
+    id: 'oracle-overall-recall',
+    label: 'Oracle overall recall including judge-primary semantic categories',
+    floor: 301,
+    denominator: 325,
+    source: 'benchmarks/oracle-corpus/oracle-results.json',
+    note: 'Structural tp plus semantic judgeTp (goal-not-fixed, cheat-mock-mutation). The semantic component replays from the committed qwen3.6 v1-conservative judge cache.',
+  },
+  {
+    id: 'real-corpus-precision-point-vs-interval',
+    label: 'Real-corpus PR-level union precision (point) held above the frozen interval floor',
+    floor: 0.09663835601719065,
+    denominator: null,
+    source: 'benchmarks/real-corpus/scores-outcome/latest.json',
+    note: 'Live point precision must stay at or above the frozen Wilson-95 lower bound. Outcome-grounded over 197 PRs at an 11.2% bad base rate; point 0.217, interval [0.097, 0.419].',
+  },
+  {
+    id: 'real-corpus-precision-wilson-lower',
+    label: 'Real-corpus PR-level union precision Wilson-95 lower bound',
+    floor: 0.09663835601719065,
+    denominator: null,
+    source: 'benchmarks/real-corpus/scores-outcome/latest.json',
+    note: 'The interval floor itself must not collapse below where it was frozen.',
+  },
+  {
+    id: 'eg-viable-count',
+    label: 'Execution-grounded-viable PRs over the 197-PR corpus',
+    floor: 12,
+    denominator: 197,
+    source: 'benchmarks/real-corpus/eg-viability.json',
+    note: 'Phase 2 (pytest and Go runners) must beat this; as a floor it must never drop. The sandbox is Node-only today, so 185 of 197 PRs are dark.',
+  },
+];
+
+/** Live metrics read from the current committed artifacts. */
+export interface LiveMetrics {
+  readonly oracleStructuralTp: number;
+  readonly oracleStructuralInjections: number;
+  readonly oracleSemanticJudgeTp: number;
+  readonly oracleSemanticInjections: number;
+  readonly realCorpusPrecisionPoint: number;
+  readonly realCorpusPrecisionWilsonLower: number;
+  readonly realCorpusRecall: number;
+  readonly realCorpusF1: number;
+  readonly realCorpusTruePositive: number;
+  readonly realCorpusFalsePositive: number;
+  readonly egViableCount: number;
+  readonly egScreened: number;
+}
+
+/** A floor the live tree failed to hold. */
+export interface Regression {
+  readonly id: string;
+  readonly label: string;
+  readonly floor: number;
+  readonly live: number;
+  readonly source: string;
+}
+
+/** Result of comparing live metrics against the frozen floors. */
+export interface BaselineEvaluation {
+  readonly pass: boolean;
+  readonly checked: number;
+  readonly regressions: readonly Regression[];
+}
+
+// Floats read from JSON are exact doubles; a tiny epsilon keeps an
+// equal-to-the-floor value (the common case on the frozen tree) from
+// tripping on representation noise.
+const EPSILON = 1e-12;
+
+/**
+ * Resolve the live value a floor is compared against. Kept explicit so the
+ * coupling between a floor id and the metric it gates is visible and typed.
+ *
+ * @throws if the id is not a known floor.
+ */
+export function liveValueForFloor(id: string, live: LiveMetrics): number {
+  switch (id) {
+    case 'oracle-structural-recall':
+      return live.oracleStructuralTp;
+    case 'oracle-overall-recall':
+      return live.oracleStructuralTp + live.oracleSemanticJudgeTp;
+    case 'real-corpus-precision-point-vs-interval':
+      return live.realCorpusPrecisionPoint;
+    case 'real-corpus-precision-wilson-lower':
+      return live.realCorpusPrecisionWilsonLower;
+    case 'eg-viable-count':
+      return live.egViableCount;
+    default:
+      throw new Error(
+        `unknown baseline floor id "${id}"; add a case to liveValueForFloor in ` +
+          'scripts/baseline/ground-truth.ts when you add a floor to GROUND_TRUTH_V12',
+      );
+  }
+}
+
+/**
+ * Compare live metrics against a set of floors.
+ *
+ * @param floors the frozen floors (normally GROUND_TRUTH_V12).
+ * @param live metrics read from the current committed artifacts.
+ * @returns pass/fail plus the list of floors the live tree dropped below.
+ */
+export function evaluateBaseline(
+  floors: readonly BaselineFloor[],
+  live: LiveMetrics,
+): BaselineEvaluation {
+  const regressions: Regression[] = [];
+  for (const f of floors) {
+    const value = liveValueForFloor(f.id, live);
+    if (value < f.floor - EPSILON) {
+      regressions.push({
+        id: f.id,
+        label: f.label,
+        floor: f.floor,
+        live: value,
+        source: f.source,
+      });
+    }
+  }
+  return { pass: regressions.length === 0, checked: floors.length, regressions };
+}
+
+// ---- artifact readers ------------------------------------------------------
+
+interface OracleCategory {
+  readonly injections: number;
+  readonly tp?: number;
+  readonly judgeTp?: number;
+}
+interface OracleResults {
+  readonly structural: OracleCategory[];
+  readonly semantic: OracleCategory[];
+}
+interface ScoresOutcome {
+  readonly aggregatePrLevel: {
+    readonly precision: number;
+    readonly recall: number;
+    readonly f1: number;
+    readonly truePositive: number;
+    readonly falsePositive: number;
+    readonly precisionWilson: { readonly lower: number };
+  };
+}
+interface EgViability {
+  readonly viableCount: number;
+  readonly screened: number;
+}
+
+function readJson<T>(file: string): T {
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `baseline source artifact not found: ${file}. Regenerate it (see the note on the ` +
+        'matching floor in GROUND_TRUTH_V12) before freezing or checking the baseline.',
+    );
+  }
+  return JSON.parse(fs.readFileSync(file, 'utf8')) as T;
+}
+
+/** Paths to the three committed artifacts the baseline reads. */
+export interface SourcePaths {
+  readonly oracleResults: string;
+  readonly scoresOutcome: string;
+  readonly egViability: string;
+}
+
+export const DEFAULT_SOURCES: SourcePaths = {
+  oracleResults: 'benchmarks/oracle-corpus/oracle-results.json',
+  scoresOutcome: 'benchmarks/real-corpus/scores-outcome/latest.json',
+  egViability: 'benchmarks/real-corpus/eg-viability.json',
+};
+
+/**
+ * Read the live metrics from the current committed artifacts.
+ *
+ * @param sources artifact paths (defaults to the canonical committed set).
+ * @returns the live metrics used for both freezing and checking.
+ * @throws if an artifact is missing or malformed.
+ */
+export function readLiveMetrics(sources: SourcePaths = DEFAULT_SOURCES): LiveMetrics {
+  const oracle = readJson<OracleResults>(sources.oracleResults);
+  let structuralTp = 0;
+  let structuralInjections = 0;
+  for (const c of oracle.structural) {
+    structuralTp += requireNumber(c.tp, 'structural.tp', sources.oracleResults);
+    structuralInjections += requireNumber(c.injections, 'structural.injections', sources.oracleResults);
+  }
+  let semanticTp = 0;
+  let semanticInjections = 0;
+  for (const c of oracle.semantic) {
+    semanticTp += requireNumber(c.judgeTp, 'semantic.judgeTp', sources.oracleResults);
+    semanticInjections += requireNumber(c.injections, 'semantic.injections', sources.oracleResults);
+  }
+
+  const scores = readJson<ScoresOutcome>(sources.scoresOutcome);
+  const agg = scores.aggregatePrLevel;
+
+  const eg = readJson<EgViability>(sources.egViability);
+
+  return {
+    oracleStructuralTp: structuralTp,
+    oracleStructuralInjections: structuralInjections,
+    oracleSemanticJudgeTp: semanticTp,
+    oracleSemanticInjections: semanticInjections,
+    realCorpusPrecisionPoint: requireNumber(agg.precision, 'aggregatePrLevel.precision', sources.scoresOutcome),
+    realCorpusPrecisionWilsonLower: requireNumber(
+      agg.precisionWilson?.lower,
+      'aggregatePrLevel.precisionWilson.lower',
+      sources.scoresOutcome,
+    ),
+    realCorpusRecall: requireNumber(agg.recall, 'aggregatePrLevel.recall', sources.scoresOutcome),
+    realCorpusF1: requireNumber(agg.f1, 'aggregatePrLevel.f1', sources.scoresOutcome),
+    realCorpusTruePositive: requireNumber(agg.truePositive, 'aggregatePrLevel.truePositive', sources.scoresOutcome),
+    realCorpusFalsePositive: requireNumber(agg.falsePositive, 'aggregatePrLevel.falsePositive', sources.scoresOutcome),
+    egViableCount: requireNumber(eg.viableCount, 'viableCount', sources.egViability),
+    egScreened: requireNumber(eg.screened, 'screened', sources.egViability),
+  };
+}
+
+function requireNumber(value: number | undefined, field: string, file: string): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(
+      `baseline artifact ${file} is missing numeric field "${field}"; the artifact shape ` +
+        'changed. Update the reader in scripts/baseline/ground-truth.ts to match.',
+    );
+  }
+  return value;
+}
+
+/** sha256 of a file's bytes, for freeze-time provenance. */
+export function sha256File(file: string): string {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+// ---- frozen reference (committed JSON) -------------------------------------
+
+/** One floor as serialized into the committed reference, plus its live value at freeze time. */
+export interface FrozenFloor extends BaselineFloor {
+  readonly liveAtFreeze: number;
+}
+
+/** The committed reference document written by freeze-ground-truth.ts. */
+export interface FrozenReference {
+  readonly schema: 'swarm.ground-truth.v12';
+  readonly generatedAt: string;
+  readonly computedBy: string;
+  readonly note: string;
+  /** sha256 of each source artifact at freeze time (provenance, not a gate). */
+  readonly sources: Record<string, { readonly sha256: string; readonly bytes: number }>;
+  readonly floors: readonly FrozenFloor[];
+  /** Informational context that is recorded but not gated (undefined-n or Phase-target metrics). */
+  readonly context: {
+    readonly realCorpusRecall: number;
+    readonly realCorpusF1: number;
+    readonly realCorpusTruePositive: number;
+    readonly realCorpusFalsePositive: number;
+    readonly egScreened: number;
+    readonly proofTierProvenFindingPrecision: {
+      readonly n: number;
+      readonly precision: number | null;
+      readonly note: string;
+    };
+  };
+}
+
+/**
+ * Build the committed reference document from the current live metrics.
+ *
+ * @param live metrics from readLiveMetrics().
+ * @param sources source paths (for provenance shas).
+ * @param generatedAt ISO timestamp for the freeze; injected so callers control it.
+ */
+export function buildFrozenReference(
+  live: LiveMetrics,
+  sources: SourcePaths,
+  generatedAt: string,
+): FrozenReference {
+  const sourceList = [sources.oracleResults, sources.scoresOutcome, sources.egViability];
+  const sourceProvenance: Record<string, { sha256: string; bytes: number }> = {};
+  for (const s of sourceList) {
+    sourceProvenance[s] = { sha256: sha256File(s), bytes: fs.statSync(s).size };
+  }
+  return {
+    schema: 'swarm.ground-truth.v12',
+    generatedAt,
+    computedBy: 'scripts/baseline/freeze-ground-truth.ts',
+    note:
+      'Frozen GROUND TRUTH the v12 upgrade must hold or beat. Floors are code constants in ' +
+      'scripts/baseline/ground-truth.ts (GROUND_TRUTH_V12); this file is the committed, ' +
+      'human-readable mirror. Guarded by npm run baseline:check. Re-freeze with ' +
+      'npm run baseline:freeze after a measured improvement, then raise the code floors to match.',
+    sources: sourceProvenance,
+    floors: GROUND_TRUTH_V12.map((f) => ({ ...f, liveAtFreeze: liveValueForFloor(f.id, live) })),
+    context: {
+      realCorpusRecall: live.realCorpusRecall,
+      realCorpusF1: live.realCorpusF1,
+      realCorpusTruePositive: live.realCorpusTruePositive,
+      realCorpusFalsePositive: live.realCorpusFalsePositive,
+      egScreened: live.egScreened,
+      proofTierProvenFindingPrecision: {
+        n: 0,
+        precision: null,
+        note: 'No fully-controlled block trigger has fired on the EG-viable slice; proven-finding precision is undefined (n=0). Recorded for honesty, not gated. Phase 4 lights this up only once n is real and the Wilson-95 lower bound clears 0.90.',
+      },
+    },
+  };
+}
+
+/**
+ * Assert the committed reference carries the same floors as GROUND_TRUTH_V12.
+ * This is the anti-tamper half of the check: a hand-edit that lowers a floor
+ * in the JSON without editing the code constant (or vice versa) is caught here.
+ *
+ * @returns null if consistent, else a message describing the mismatch.
+ */
+export function referenceMatchesConstants(ref: FrozenReference): string | null {
+  const strip = (f: BaselineFloor): BaselineFloor => ({
+    id: f.id,
+    label: f.label,
+    floor: f.floor,
+    denominator: f.denominator,
+    source: f.source,
+    note: f.note,
+  });
+  const fromFile = ref.floors.map(strip);
+  const fromCode = GROUND_TRUTH_V12.map(strip);
+  if (JSON.stringify(fromFile) !== JSON.stringify(fromCode)) {
+    return (
+      'the committed reference floors do not match GROUND_TRUTH_V12 in ' +
+      'scripts/baseline/ground-truth.ts. Someone edited one without the other. ' +
+      'Re-run: npm run baseline:freeze (and, if you intend to move the bar, edit the code ' +
+      'constant first).'
+    );
+  }
+  return null;
+}

--- a/test/scripts/baseline/ground-truth.test.ts
+++ b/test/scripts/baseline/ground-truth.test.ts
@@ -1,0 +1,149 @@
+import { strict as assert } from 'assert';
+import * as path from 'path';
+import {
+  buildFrozenReference,
+  evaluateBaseline,
+  GROUND_TRUTH_V12,
+  liveValueForFloor,
+  readLiveMetrics,
+  referenceMatchesConstants,
+  type LiveMetrics,
+  type SourcePaths,
+} from '../../../scripts/baseline/ground-truth';
+
+// Live metrics sitting exactly on every gated floor. Overrides let each test
+// push one metric below its floor without disturbing the others.
+function liveAtFloor(over: Partial<LiveMetrics> = {}): LiveMetrics {
+  return {
+    oracleStructuralTp: 258,
+    oracleStructuralInjections: 275,
+    oracleSemanticJudgeTp: 43,
+    oracleSemanticInjections: 50,
+    realCorpusPrecisionPoint: 0.09663835601719065,
+    realCorpusPrecisionWilsonLower: 0.09663835601719065,
+    realCorpusRecall: 0.227,
+    realCorpusF1: 0.222,
+    realCorpusTruePositive: 5,
+    realCorpusFalsePositive: 18,
+    egViableCount: 12,
+    egScreened: 197,
+    ...over,
+  };
+}
+
+// The repo root, resolved from the compiled test location so the integration
+// test does not depend on the process cwd.
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const COMMITTED_SOURCES: SourcePaths = {
+  oracleResults: path.join(REPO_ROOT, 'benchmarks/oracle-corpus/oracle-results.json'),
+  scoresOutcome: path.join(REPO_ROOT, 'benchmarks/real-corpus/scores-outcome/latest.json'),
+  egViability: path.join(REPO_ROOT, 'benchmarks/real-corpus/eg-viability.json'),
+};
+
+describe('scripts/baseline/ground-truth evaluateBaseline', () => {
+  it('passes when every live metric sits exactly on its frozen floor', () => {
+    const result = evaluateBaseline(GROUND_TRUTH_V12, liveAtFloor());
+    assert.equal(result.pass, true);
+    assert.equal(result.regressions.length, 0);
+    assert.equal(result.checked, GROUND_TRUTH_V12.length);
+  });
+
+  it('passes when a live metric exceeds its floor', () => {
+    const result = evaluateBaseline(GROUND_TRUTH_V12, liveAtFloor({ oracleStructuralTp: 270 }));
+    assert.equal(result.pass, true);
+  });
+
+  it('flags oracle structural recall dropping one below the floor', () => {
+    const result = evaluateBaseline(GROUND_TRUTH_V12, liveAtFloor({ oracleStructuralTp: 257 }));
+    assert.equal(result.pass, false);
+    const ids = result.regressions.map((r) => r.id);
+    // A drop in structural tp regresses both the structural and overall floors.
+    assert.ok(ids.includes('oracle-structural-recall'));
+    assert.ok(ids.includes('oracle-overall-recall'));
+  });
+
+  it('flags real-corpus precision point falling below the frozen interval floor', () => {
+    const result = evaluateBaseline(
+      GROUND_TRUTH_V12,
+      liveAtFloor({ realCorpusPrecisionPoint: 0.05 }),
+    );
+    assert.equal(result.pass, false);
+    assert.deepEqual(
+      result.regressions.map((r) => r.id),
+      ['real-corpus-precision-point-vs-interval'],
+    );
+  });
+
+  it('flags the Wilson lower bound collapsing below the frozen floor', () => {
+    const result = evaluateBaseline(
+      GROUND_TRUTH_V12,
+      liveAtFloor({ realCorpusPrecisionWilsonLower: 0.0 }),
+    );
+    assert.equal(result.pass, false);
+    assert.deepEqual(
+      result.regressions.map((r) => r.id),
+      ['real-corpus-precision-wilson-lower'],
+    );
+  });
+
+  it('flags a drop in execution-grounded viability', () => {
+    const result = evaluateBaseline(GROUND_TRUTH_V12, liveAtFloor({ egViableCount: 11 }));
+    assert.equal(result.pass, false);
+    assert.deepEqual(
+      result.regressions.map((r) => r.id),
+      ['eg-viable-count'],
+    );
+  });
+
+  it('reports every regressed floor, not just the first', () => {
+    const result = evaluateBaseline(
+      GROUND_TRUTH_V12,
+      liveAtFloor({ oracleStructuralTp: 200, egViableCount: 0, realCorpusPrecisionPoint: 0 }),
+    );
+    assert.equal(result.pass, false);
+    // structural + overall (both driven by structuralTp) + precision-point + eg = 4.
+    assert.equal(result.regressions.length, 4);
+  });
+});
+
+describe('scripts/baseline/ground-truth liveValueForFloor', () => {
+  it('sums structural and semantic true positives for the overall floor', () => {
+    const value = liveValueForFloor('oracle-overall-recall', liveAtFloor());
+    assert.equal(value, 301);
+  });
+
+  it('throws on an unknown floor id', () => {
+    assert.throws(() => liveValueForFloor('not-a-floor', liveAtFloor()), /unknown baseline floor id/);
+  });
+});
+
+describe('scripts/baseline/ground-truth referenceMatchesConstants', () => {
+  it('accepts a freshly built reference whose floors mirror GROUND_TRUTH_V12', () => {
+    const ref = buildFrozenReference(liveAtFloor(), COMMITTED_SOURCES, '2026-07-06T00:00:00.000Z');
+    assert.equal(referenceMatchesConstants(ref), null);
+  });
+
+  it('rejects a reference whose floor was hand-lowered', () => {
+    const ref = buildFrozenReference(liveAtFloor(), COMMITTED_SOURCES, '2026-07-06T00:00:00.000Z');
+    const tampered = {
+      ...ref,
+      floors: ref.floors.map((f) =>
+        f.id === 'oracle-overall-recall' ? { ...f, floor: 250 } : f,
+      ),
+    };
+    const message = referenceMatchesConstants(tampered);
+    assert.ok(message !== null);
+    assert.match(message ?? '', /do not match GROUND_TRUTH_V12/);
+  });
+});
+
+describe('scripts/baseline/ground-truth against the committed tree', () => {
+  it('holds every frozen floor on the current committed artifacts', () => {
+    const live = readLiveMetrics(COMMITTED_SOURCES);
+    // Sanity: the committed oracle really is 301/325.
+    assert.equal(live.oracleStructuralTp + live.oracleSemanticJudgeTp, 301);
+    assert.equal(live.oracleStructuralInjections + live.oracleSemanticInjections, 325);
+    const result = evaluateBaseline(GROUND_TRUTH_V12, live);
+    assert.equal(result.pass, true, JSON.stringify(result.regressions));
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -22,6 +22,7 @@
     "scripts/labeling/**/*",
     "scripts/promotions/**/*",
     "scripts/gate/**/*",
+    "scripts/baseline/**/*",
     "scripts/benchmarks/**/*",
     "scripts/oracle/**/*",
     "scripts/real-prs/**/*",


### PR DESCRIPTION
## Phase 0 — freeze the baseline

Pins the measured GROUND TRUTH the v12 autonomous-merge upgrade must hold or beat, and wires a CI guard that fails on regression. This is the reference every later phase is checked against.

### What lands
- **Frozen floors as code constants** (`GROUND_TRUTH_V12` in `scripts/baseline/ground-truth.ts`). The bar cannot be lowered by hand-editing a JSON: the check asserts the committed reference still carries the code floors.
- **Committed reference** `benchmarks/baselines/ground-truth-v12.json`, the human-readable mirror with per-source sha256 provenance, regenerated by `npm run baseline:freeze`.
- **CI guard** `npm run baseline:check`, wired next to `promotions:check` and `block-policy:check`.

### The five floors (each read back from a committed artifact, never re-derived)
| floor | value | source |
|---|---|---|
| oracle structural recall | 258/275 (deterministic, no judge) | `benchmarks/oracle-corpus/oracle-results.json` |
| oracle overall recall | 301/325 (folds 2 judge-primary semantic categories, replayed from the committed qwen3.6 cache) | same |
| real-corpus precision point vs interval | held at/above Wilson-95 lower 0.0966 (point 0.217) | `benchmarks/real-corpus/scores-outcome/latest.json` |
| real-corpus precision Wilson-95 lower | 0.0966 (the interval floor itself) | same |
| execution-grounded-viable | 12/197 (Phase 2 must beat this) | `benchmarks/real-corpus/eg-viability.json` |

Proof-tier proven-finding precision (n=0, undefined) is recorded as context, not gated: no floor to hold on an undefined-n statistic.

### Verification
- `npm test`: 1969 passing, 0 failing, 34 pending (12 new behavior tests for the evaluator, plus an integration test proving the floors hold on the committed tree).
- `npm run typecheck`: clean.
- `npm run baseline:check`: `all 5 floors held (oracle 301/325, real-corpus precision 0.217 [wilson-lower 0.097], eg-viable 12/197)`.
- LOC budget: PASS (guard logic sits in `scripts/`, costs no `src/` budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)